### PR TITLE
Bug in dataset caching

### DIFF
--- a/src/dataloaders/synthetics.py
+++ b/src/dataloaders/synthetics.py
@@ -302,13 +302,14 @@ class ICLDataModule(SequenceDataset):
                 test_tensor[:, 1, :-1] = -100
             if self.copy_method in ["majority", "fom1"]:
                 train_tensor[:, 1, :-1 * (self.num_extra_seq_len - 1)] = -100
-            
-            torch.save(train_tensor, os.path.join(self.data_dir, 
-                f"train_{self.copy_method}_{self.num_examples}_{self.vocab_size}_{self.input_seq_len}.pt")
-            )
-            torch.save(test_tensor, os.path.join(self.data_dir, 
-                f"test_{self.copy_method}_{self.num_examples}_{self.vocab_size}_{self.input_seq_len}.pt")
-            )  
+
+            if self.data_dir is not None:
+                torch.save(train_tensor, os.path.join(self.data_dir,
+                    f"train_{self.copy_method}_{self.num_examples}_{self.vocab_size}_{self.input_seq_len}.pt")
+                )
+                torch.save(test_tensor, os.path.join(self.data_dir,
+                    f"test_{self.copy_method}_{self.num_examples}_{self.vocab_size}_{self.input_seq_len}.pt")
+                )
              
         self.dataset = {
             'train': TensorDataset(train_tensor[:, 0, :], train_tensor[:, 1, :]),


### PR DESCRIPTION
There seems to be a bug in synthetic dataset `ICLDataModule` caching system: `self.data_dir` is not check on None before caching dataset. Because of that standard runs that are listed in `experiments.md`, for example this one:
```
python -m train experiment=synthetics/associative_recall/transformer
```
fails with null pointer exception.

I fixed it. 